### PR TITLE
fix: remove case of named export

### DIFF
--- a/packages/keep-export/package.json
+++ b/packages/keep-export/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ice/swc-plugin-keep-export",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "license": "MIT",
     "keywords": ["swc-plugin"],
     "main": "swc_plugin_keep_export.wasm",

--- a/packages/keep-export/src/lib.rs
+++ b/packages/keep-export/src/lib.rs
@@ -98,9 +98,20 @@ impl Fold for Analyzer<'_> {
     }
 
     fn fold_export_named_specifier(&mut self, s: ExportNamedSpecifier) -> ExportNamedSpecifier {
-        if let ModuleExportName::Ident(id) = &s.orig {
-            if self.state.should_keep_identifier(id) {
-                self.add_ref(id.to_id());
+        if let ModuleExportName::Ident(i) = &s.orig {
+            match &s.exported {
+                Some(exported) => {
+                    if let ModuleExportName::Ident(e) = exported {
+                        if self.state.should_keep_identifier(e) {
+                            self.add_ref(i.to_id());
+                        }
+                    }
+                }
+                None => {
+                    if self.state.should_keep_identifier(i) {
+                        self.add_ref(i.to_id());
+                    }
+                }
             }
         }
 
@@ -268,14 +279,6 @@ impl Fold for Analyzer<'_> {
         let s = s.fold_children_with(self);
 
         s
-    }
-
-    fn fold_named_export(&mut self, mut n: NamedExport) -> NamedExport {
-        if n.src.is_some() {
-            n.specifiers = n.specifiers.fold_with(self);
-        }
-
-        n
     }
 
     fn fold_default_decl(&mut self, d: DefaultDecl) -> DefaultDecl {

--- a/packages/keep-export/tests/fixtrue.rs
+++ b/packages/keep-export/tests/fixtrue.rs
@@ -237,3 +237,21 @@ fn fixture_remove_top_try_catch(input: PathBuf) {
     }
   );
 }
+
+#[fixture("tests/fixture/remove-named-export/input.js")]
+fn fixture_remove_named_export(input: PathBuf) {
+  let parent = input.parent().unwrap();
+  let output = parent.join("output.js");
+
+  test_fixture(
+    Default::default(),
+    &|_t| {
+      keep_exprs([String::from("getData")].to_vec())
+    },
+    &input,
+    &output,
+    FixtureTestConfig {
+      ..Default::default()
+    }
+  );
+}

--- a/packages/keep-export/tests/fixture/remove-named-export/input.js
+++ b/packages/keep-export/tests/fixture/remove-named-export/input.js
@@ -1,0 +1,8 @@
+function getData() {}
+function defineAppConfig() {}
+function getConfig() {}
+
+export {
+  defineAppConfig,
+  getConfig as getData,
+}

--- a/packages/keep-export/tests/fixture/remove-named-export/output.js
+++ b/packages/keep-export/tests/fixture/remove-named-export/output.js
@@ -1,0 +1,4 @@
+function getConfig() {}
+export {
+  getConfig as getData,
+}


### PR DESCRIPTION
Fix bug of the case which function statement will be removed if declared with named export statement.